### PR TITLE
fix(updates/sdk): correctly handle no Titanium CLI being installed when checking for SDK updates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,8 @@
 name: Publish
 on:
-  release:
-    types: [ created ]
+  push:
+    branches:
+      - master
 
 jobs:
   publish:
@@ -28,4 +29,4 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      run: npm publish
+      run: npm run release

--- a/src/updates/alloy/index.ts
+++ b/src/updates/alloy/index.ts
@@ -4,7 +4,7 @@ import { ProductNames, UpdateInfo } from '..';
 import { checkInstalledNpmPackageVersion, checkLatestNpmPackageVersion, installNpmPackage } from '../util';
 
 export async function checkInstalledVersion(): Promise<string|undefined> {
-	return  checkInstalledNpmPackageVersion('alloy');
+	return checkInstalledNpmPackageVersion('alloy');
 }
 
 export async function checkLatestVersion(): Promise<string> {

--- a/src/updates/titanium/sdk.ts
+++ b/src/updates/titanium/sdk.ts
@@ -92,7 +92,9 @@ export async function checkLatestVersion (): Promise<SDKInfo> {
 	let releases;
 	try {
 		const { stdout } = await runTiCommand([ 'sdk', 'list', '--releases', '--output', 'json' ]);
-		releases = Object.keys(JSON.parse(stdout).releases).map(name => name.replace('.GA', ''));
+		releases = Object.keys(JSON.parse(stdout).releases)
+			.filter(release => release.endsWith('GA'))
+			.map(name => name.replace('.GA', ''));
 	} catch (error) {
 		if (error instanceof InstallError) {
 			throw error;
@@ -106,7 +108,7 @@ export async function checkLatestVersion (): Promise<SDKInfo> {
 		};
 	}
 
-	const latest = releases?.sort(semver.rcompare)[0];
+	const latest = releases.sort(semver.rcompare)[0];
 	return {
 		name: `${latest}.GA`,
 		version: latest

--- a/src/updates/titanium/sdk.ts
+++ b/src/updates/titanium/sdk.ts
@@ -89,10 +89,24 @@ export async function checkInstalledVersion (validateSelected = false): Promise<
 }
 
 export async function checkLatestVersion (): Promise<SDKInfo> {
-	const { stdout } = await runTiCommand([ 'sdk', 'list', '--releases', '--output', 'json' ]);
-	const releases = Object.keys(JSON.parse(stdout).releases).map(name => name.replace('.GA', ''));
-	const latest = releases.sort(semver.rcompare)[0];
+	let releases;
+	try {
+		const { stdout } = await runTiCommand([ 'sdk', 'list', '--releases', '--output', 'json' ]);
+		releases = Object.keys(JSON.parse(stdout).releases).map(name => name.replace('.GA', ''));
+	} catch (error) {
+		if (error instanceof InstallError) {
+			throw error;
+		}
+	}
 
+	if (!releases) {
+		return {
+			name: 'latest',
+			version: 'latest'
+		};
+	}
+
+	const latest = releases?.sort(semver.rcompare)[0];
 	return {
 		name: `${latest}.GA`,
 		version: latest
@@ -112,6 +126,9 @@ export async function installUpdate (version: string): Promise<void> {
 }
 
 export function getReleaseNotes (version: string): string {
+	if (version === 'latest') {
+		return 'https://titaniumsdk.com/guide/Titanium_SDK/Titanium_SDK_Release_Notes/';
+	}
 	// https://titaniumsdk.com/guide/Titanium_SDK/Titanium_SDK_Release_Notes/Titanium_SDK_Release_Notes_10.x/Titanium_SDK_10.0.0.GA_Release_Note.html
 	const versionData = semver.parse(semver.coerce(version));
 	if (!versionData) {
@@ -127,7 +144,7 @@ export async function checkForUpdate (): Promise<UpdateInfo> {
 	]);
 
 	const updateInfo: UpdateInfo = {
-		currentVersion: currentVersion ? currentVersion.name : '',
+		currentVersion: currentVersion?.name || undefined,
 		latestVersion: latestVersion.name,
 		action: installUpdate,
 		productName: ProductNames.TitaniumSDK,

--- a/tests/updates-test.ts
+++ b/tests/updates-test.ts
@@ -54,7 +54,7 @@ describe('updates', () => {
 			mockSdkListReleases(stub);
 
 			const update = await titanium.sdk.checkForUpdate();
-			expect(update.currentVersion).to.equal('');
+			expect(update.currentVersion).to.equal(undefined);
 			expect(update.latestVersion).to.equal('8.0.0.GA');
 			expect(update.productName).to.equal('Titanium SDK');
 			expect(update.hasUpdate).to.equal(true);
@@ -71,6 +71,20 @@ describe('updates', () => {
 			expect(update.latestVersion).to.equal('8.0.0.GA');
 			expect(update.productName).to.equal('Titanium SDK');
 			expect(update.hasUpdate).to.equal(false);
+		});
+
+		it('checkForUpdate with no CLI installed', async () => {
+			const stub: sinon.SinonStub = sandbox.stub(util, 'exec');
+
+			mockSdkList(stub, '8.0.0');
+			mockSdkListReleases(stub);
+			mockNpmCli(stub, 'titanium', undefined);
+
+			const update = await titanium.sdk.checkForUpdate();
+			expect(update.currentVersion).to.equal(undefined);
+			expect(update.latestVersion).to.equal('latest');
+			expect(update.productName).to.equal('Titanium SDK');
+			expect(update.hasUpdate).to.equal(true);
 		});
 
 		it('install with titanium cli', async () => {


### PR DESCRIPTION
The failure to run the SDK command would bubble up and throw causing checkUpdates to fail. Instead, fallback to returning `latest` instead