### PR TITLE
feat(install/sdk): check that the selected SDK is installed when validating environment

### DIFF
--- a/src/completions/generate-v1.ts
+++ b/src/completions/generate-v1.ts
@@ -2,7 +2,8 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 
 import { CompletionsFormat, PropertiesDictionary, TagDictionary, TypeDictionary  } from './index';
-import { CustomError, findAlloy, getAlloyCompletionsFileName, getSDKCompletionsFileName } from './util';
+import { findAlloy, getAlloyCompletionsFileName, getSDKCompletionsFileName } from './util';
+import { CustomError } from '../util';
 
 /**
  * Generate completions for an Alloy version.

--- a/src/completions/generate-v2.ts
+++ b/src/completions/generate-v2.ts
@@ -2,7 +2,8 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 
 import { CompletionsFormat, JSCA, PropertiesDictionary, TagDictionary, TypeDictionary } from './index';
-import { CustomError, findAlloy, getAlloyCompletionsFileName, getSDKCompletionsFileName } from './util';
+import { findAlloy, getAlloyCompletionsFileName, getSDKCompletionsFileName } from './util';
+import { CustomError } from '../util';
 
 async function parseJSCA (api: JSCA): Promise<{ props: PropertiesDictionary; types: TypeDictionary }> {
 	const types: TypeDictionary = {};

--- a/src/completions/generate-v3.ts
+++ b/src/completions/generate-v3.ts
@@ -2,7 +2,8 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 
 import { CompletionsFormat, JSCA, PropertiesDictionary, TagDictionary, TypeDictionary } from './index';
-import { CustomError, findAlloy, getAlloyCompletionsFileName, getSDKCompletionsFileName } from './util';
+import { findAlloy, getAlloyCompletionsFileName, getSDKCompletionsFileName } from './util';
+import { CustomError } from '../util';
 
 async function parseJSCA (api: JSCA): Promise<{ props: PropertiesDictionary; types: TypeDictionary }> {
 	const types: TypeDictionary = {};

--- a/src/completions/util.ts
+++ b/src/completions/util.ts
@@ -5,15 +5,6 @@ import { exec } from '../util';
 
 import os from 'os';
 
-export class CustomError extends Error {
-
-	public code: string;
-	constructor (message: string, code: string) {
-		super(message);
-		this.code = code;
-	}
-}
-
 export function getSDKCompletionsFileName (sdkVersion: string, completionsVersion: number): string {
 	return path.join(os.homedir(), '.titanium', 'completions', 'titanium', sdkVersion, `completions-v${completionsVersion}.json`);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,7 @@
 import * as completion from './completions';
 import * as environment from './environment';
 import * as updates from './updates';
-import { InstallError } from './util';
-import { CustomError } from './completions/util';
+import { InstallError, CustomError } from './util';
 
 const Errors = {
 	CustomError,

--- a/src/util.ts
+++ b/src/util.ts
@@ -9,6 +9,21 @@ interface InstallErrorMetadata {
 	command?: string;
 }
 
+export interface Action {
+	title: string;
+	run: () => Promise<void>;
+}
+export class CustomError extends Error {
+
+	public actions: Action[]|undefined;
+	public code: string;
+	constructor(message: string, code: string, actions?: Action[]) {
+		super(message);
+		this.actions = actions;
+		this.code = code;
+	}
+}
+
 export class InstallError extends Error {
 	public code: string;
 	public metadata: InstallErrorMetadata;

--- a/tests/completions-test.ts
+++ b/tests/completions-test.ts
@@ -1,6 +1,5 @@
 import * as util from '../src/util';
 import { CompletionsFormat, generateAlloyCompletions, generateSDKCompletions, loadCompletions } from '../src/completions';
-import { CustomError } from '../src/completions/util';
 
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
@@ -108,9 +107,9 @@ describe('completions', () => {
 			try {
 				await generateSDKCompletions(true, '8.1.0.GA', '', CompletionsFormat.v1);
 			} catch (error) {
-				expect(error).to.be.instanceOf(CustomError);
-				expect((error as CustomError).message).to.equal('The current projects SDK version 8.1.0.GA, is not installed. Please update the SDK version in the tiapp to generate autocomplete suggestions.');
-				expect((error as CustomError).code).to.equal('ESDKNOTINSTALLED');
+				expect(error).to.be.instanceOf(util.CustomError);
+				expect((error as util.CustomError).message).to.equal('The current projects SDK version 8.1.0.GA, is not installed. Please update the SDK version in the tiapp to generate autocomplete suggestions.');
+				expect((error as util.CustomError).code).to.equal('ESDKNOTINSTALLED');
 			}
 		});
 		it('Generate SDK Completions with pre-existing completions', async () => {

--- a/tests/environment-test.ts
+++ b/tests/environment-test.ts
@@ -87,5 +87,15 @@ describe('environment', () => {
 				]
 			);
 		});
+
+		it('validateEnvironment with installed SDKs', async () => {
+			const stub = sandbox.stub(util, 'exec');
+			mockNode(stub, '12.18.1');
+			mockNpmCli(stub, 'titanium', '5.3.0');
+			mockNpmCli(stub, 'alloy', '1.15.3');
+			mockSdkList(stub, '8.0.0', '7.0.0');
+
+			expect(environment.validateEnvironment()).to.eventually.throw(util.CustomError, 'Selected SDK 7.0.0.GA is not installed');
+		});
 	});
 });

--- a/tests/updates-test.ts
+++ b/tests/updates-test.ts
@@ -89,6 +89,24 @@ describe('updates', () => {
 		it('getReleaseNotes() should throw if cant determine major version', () => {
 			expect(() => titanium.sdk.getReleaseNotes('foo')).to.throw(Error, 'Failed to parse major version from foo');
 		});
+
+		it('should handle active sdk not matching', async () => {
+			const stub: sinon.SinonStub = sandbox.stub(util, 'exec');
+
+			mockSdkList(stub, '8.0.0', '7.0.0');
+			mockSdkListReleases(stub);
+
+			expect(titanium.sdk.checkForUpdate()).to.eventually.throw(util.CustomError, 'Selected SDK 7.0.0.GA is not installed');
+		});
+
+		it('should handle active sdk not matching and no sdk installed', async () => {
+			const stub: sinon.SinonStub = sandbox.stub(util, 'exec');
+
+			mockSdkList(stub, undefined, '7.0.0');
+			mockSdkListReleases(stub);
+
+			expect(titanium.sdk.checkForUpdate()).to.eventually.throw(util.CustomError, 'Selected SDK 7.0.0.GA is not installed');
+		});
 	});
 
 	describe('node', () => {

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -89,78 +89,84 @@ export function mockSdkListReleases(stub: sinon.SinonStub): void {
  *
  * @param {sinon.SinonStub} stub - The sinon stub instance
  * @param {String} version - The version to insert, if the value is undefined then an empty array will be returned
+ * @param {String} activeSDK - The version to set as the active/selected SDK
  */
-export function mockSdkList (stub: sinon.SinonStub, version?: string): void {
-	mockNpmCli(stub, 'titanium', '5.3.0');
-	if (version) {
-		stub
-			.withArgs('ti', [ 'sdk', 'list', '--output', 'json' ], sinon.match.any)
-			.resolves({ stdout: `{
-				"sdks": {
-					"7.0.2.GA": {
-						"name": "7.0.2.GA",
-						"manifest": {
-							"name": "7.0.2.v20180209105903",
-							"version": "7.0.2",
-							"moduleAPIVersion": {
-								"iphone": "2",
-								"android": "4",
-								"windows": "4"
-							},
-							"timestamp": "2/9/2018 19:05",
-							"githash": "5ef0c56",
-							"platforms": [
-								"iphone",
-								"android"
-							]
-						},
-						"path": "/Users/tester/Library/Application Support/Titanium/mobilesdk/osx/7.0.2.GA"
-					},
-					"8.1.0.v20190416065710": {
-						"name": "8.1.0.v20190416065710",
-						"manifest": {
-							"name": "8.1.0.v20190416065710",
-							"version": "8.1.0",
-							"moduleAPIVersion": {
-								"iphone": "2",
-								"android": "4",
-								"windows": "7"
-							},
-							"timestamp": "4/16/2019 14:03",
-							"githash": "37f6d88",
-							"platforms": [
-								"iphone",
-								"android"
-							]
-						},
-						"path": "/Users/tester/Library/Application Support/Titanium/mobilesdk/osx/8.1.0.v20190416065710"
-					},
-					"${version}.GA": {
-						"name": "${version}.GA",
-						"manifest": {
-							"name": "${version}.v20181115134726",
-							"version": "${version}",
-							"moduleAPIVersion": {
-								"iphone": "2",
-								"android": "4",
-								"windows": "6"
-							},
-							"timestamp": "11/15/2018 21:52",
-							"githash": "2e5a7423d0",
-							"platforms": [
-								"iphone",
-								"android"
-							]
-						},
-						"path": "/Users/tester/Library/Application Support/Titanium/mobilesdk/osx/${version}.GA"
-					}
-				}
-			}` });
-	} else {
-		stub
-			.withArgs('ti', [ 'sdk', 'list', '--output', 'json' ], sinon.match.any)
-			.resolves({ stdout: '{ "sdks": {} }' });
+export function mockSdkList (stub: sinon.SinonStub, version?: string, activeSDK?: string): void {
+	if (version && !activeSDK) {
+		activeSDK = version;
 	}
+
+	const output = {
+		activeSDK: activeSDK ? `${activeSDK}.GA` : undefined,
+		sdks: {}
+	};
+
+	if (version) {
+		output.sdks = {
+			'7.0.2.GA': {
+				name: '7.0.2.GA',
+				manifest: {
+					name: '7.0.2.v20180209105903',
+					version: '7.0.2',
+					moduleAPIVersion: {
+						iphone: '2',
+						android: '4',
+						windows: '4'
+					},
+					timestamp: '2/9/2018 19:05',
+					githash: '5ef0c56',
+					platforms: [
+						'iphone',
+						'android'
+					]
+				},
+				path: '/Users/tester/Library/Application Support/Titanium/mobilesdk/osx/7.0.2.GA'
+			},
+			'8.1.0.v20190416065710': {
+				name: '8.1.0.v20190416065710',
+				manifest: {
+					name: '8.1.0.v20190416065710',
+					version: '8.1.0',
+					moduleAPIVersion: {
+						iphone: '2',
+						android: '4',
+						windows: '7'
+					},
+					timestamp: '4/16/2019 14:03',
+					githash: '37f6d88',
+					platforms: [
+						'iphone',
+						'android'
+					]
+				},
+				path: '/Users/tester/Library/Application Support/Titanium/mobilesdk/osx/8.1.0.v20190416065710'
+			},
+			[`${version}.GA`]: {
+				name: `${version}.GA`,
+				manifest: {
+					name: `${version}.v20181115134726`,
+					version: `${version}`,
+					moduleAPIVersion: {
+						iphone: '2',
+						android: '4',
+						windows: '6'
+					},
+					timestamp: '11/15/2018 21:52',
+					githash: '2e5a7423d0',
+					platforms: [
+						'iphone',
+						'android'
+					]
+				},
+				path: `/Users/tester/Library/Application Support/Titanium/mobilesdk/osx/${version}.GA`
+			}
+		};
+	}
+
+	mockNpmCli(stub, 'titanium', '5.3.0');
+	stub
+		.withArgs('ti', [ 'sdk', 'list', '--output', 'json' ], sinon.match.any)
+		.resolves({ stdout: JSON.stringify(output) });
 }
 
 /**


### PR DESCRIPTION
Sets up the VS Code change for tidev/vscode-titanium/issues/1020

Summary of changes: 

* Moves `CustomError` to the top level utils
* Introduces `issues` to the validateEnvironment return value that will allow VS Code to present different messaging for missing tooling and environment issues
  * This could potentially allow us to add more issue detection in future like missing Android/iOS tooling
* Adds selected SDK validation into the `checkInstalledVersion` for SDK
* Adds tests for the new feature
  * Related update to the SDK list mock to help with the new tests